### PR TITLE
[FEAT] 게시판 일기 조회 API 구현

### DIFF
--- a/src/controllers/DiaryController.ts
+++ b/src/controllers/DiaryController.ts
@@ -86,6 +86,40 @@ const getDiaryById = async (req: Request, res: Response) => {
   }
 };
 
+const getOpenDiaries = async (req: Request, res: Response) => {
+  const { userId } = req.body;
+
+  try {
+    const data = await DiaryService.getOpenDiaries(+userId);
+
+    if (data === statusCode.UNAUTHORIZED) {
+      return res
+        .status(status.UNAUTHORIZED)
+        .send(fail(status.UNAUTHORIZED, message.INVALID_TOKEN));
+    }
+
+    if (data === statusCode.INTERNAL_SERVER_ERROR) {
+      return res
+        .status(status.INTERNAL_SERVER_ERROR)
+        .send(
+          fail(status.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR),
+        );
+    }
+
+    return res
+      .status(status.OK)
+      .send(success(status.OK, message.GET_DIARY_LIST_SUCCESS, data));
+  } catch (error) {
+    const log = slackMessage(
+      req.method.toUpperCase(),
+      req.originalUrl,
+      error,
+      userId,
+    );
+    slack(log);
+  }
+};
+
 const deleteDiary = async (req: Request, res: Response) => {
   const { diaryId } = req.params;
   const { userId } = req.body;
@@ -124,6 +158,7 @@ const deleteDiary = async (req: Request, res: Response) => {
 const diaryController = {
   createDiary,
   getDiaryById,
+  getOpenDiaries,
   deleteDiary,
 };
 

--- a/src/interfaces/diary/DiaryResponseDto.ts
+++ b/src/interfaces/diary/DiaryResponseDto.ts
@@ -9,3 +9,14 @@ export interface DiaryResponseDto {
   username: string;
   bio: string;
 }
+
+export interface OpenDiaryResponseDto {
+  diaryId: number;
+  content: string;
+  likeCnt: number;
+  userId: number;
+  username: string;
+  isSeen: boolean;
+  hasLike: number;
+  createdAt: string;
+}

--- a/src/interfaces/diary/DiaryResponseDto.ts
+++ b/src/interfaces/diary/DiaryResponseDto.ts
@@ -17,6 +17,6 @@ export interface OpenDiaryResponseDto {
   userId: number;
   username: string;
   isSeen: boolean;
-  hasLike: number;
+  hasLike: boolean;
   createdAt: string;
 }

--- a/src/routers/DiaryRouter.ts
+++ b/src/routers/DiaryRouter.ts
@@ -19,6 +19,8 @@ router.post(
 
 router.get("/:diaryId", DiaryController.getDiaryById);
 
+router.get("/", DiaryController.getOpenDiaries);
+
 router.delete("/:diaryId", DiaryController.deleteDiary);
 
 export default router;

--- a/src/services/DiaryService.ts
+++ b/src/services/DiaryService.ts
@@ -147,11 +147,15 @@ const getOpenDiaries = async (userId: number) => {
         ? true
         : false;
 
-    const hasLike = await prisma.likes.count({
-      where: {
-        diary_id: diary.id,
-      },
-    });
+    const hasLike =
+      (await prisma.likes.count({
+        where: {
+          diary_id: diary.id,
+          user_id: userId,
+        },
+      })) > 0
+        ? true
+        : false;
 
     const writer = await prisma.users.findUnique({
       where: {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #54 

## Work Description 💚
- 게시판 일기 조회 API 구현을 완료했습니다.
- 로그온 상태의 유저 일기를 제외한 게시글 목록 조회 가능