### PR TITLE
[FIX] 게시판 일기 상세조회 기능 수정

### DIFF
--- a/src/controllers/DiaryController.ts
+++ b/src/controllers/DiaryController.ts
@@ -74,7 +74,7 @@ const getDiaryById = async (req: Request, res: Response) => {
 
     return res
       .status(status.OK)
-      .send(success(status.OK, message.GET_CATEGORY_SUCCESS, data));
+      .send(success(status.OK, message.GET_DIADY_SUCCESS, data));
   } catch (error) {
     const log = slackMessage(
       req.method.toUpperCase(),

--- a/src/interfaces/diary/DiaryResponseDto.ts
+++ b/src/interfaces/diary/DiaryResponseDto.ts
@@ -8,4 +8,5 @@ export interface DiaryResponseDto {
   userId: number;
   username: string;
   bio: string;
+  hasLike: boolean;
 }

--- a/src/services/DiaryService.ts
+++ b/src/services/DiaryService.ts
@@ -94,6 +94,16 @@ const getDiaryById = async (diaryId: number, userId: number) => {
     },
   });
 
+  const writer = await prisma.users.findUnique({
+    where: {
+      id: diary.user_id,
+    },
+  });
+
+  if (!writer) {
+    return statusCode.INTERNAL_SERVER_ERROR;
+  }
+
   const date = dayjs(diary.created_at).format("YYYY-MM-DD HH:mm");
 
   const data: DiaryResponseDto = {
@@ -103,9 +113,9 @@ const getDiaryById = async (diaryId: number, userId: number) => {
     topic: topic.content,
     likeCnt: likeCnt,
     createdAt: date,
-    userId: userId,
-    username: user.username as string,
-    bio: user.bio as string,
+    userId: writer.id,
+    username: writer.username as string,
+    bio: writer.bio as string,
   };
 
   return data;

--- a/src/services/DiaryService.ts
+++ b/src/services/DiaryService.ts
@@ -94,6 +94,16 @@ const getDiaryById = async (diaryId: number, userId: number) => {
     },
   });
 
+  const hasLike =
+    (await prisma.likes.count({
+      where: {
+        diary_id: diaryId,
+        user_id: userId,
+      },
+    })) > 0
+      ? true
+      : false;
+
   const writer = await prisma.users.findUnique({
     where: {
       id: diary.user_id,
@@ -116,6 +126,7 @@ const getDiaryById = async (diaryId: number, userId: number) => {
     userId: writer.id,
     username: writer.username as string,
     bio: writer.bio as string,
+    hasLike: hasLike,
   };
 
   return data;


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #57 

## Work Description 💚
- 반환 메세지 변경했습니다.
- 로그온 되어 있는 사용자의 해당 일기 추천 여부 데이터를 추가했습니다.
- 해당 일기의 유저 데이터를 로그온에서 작성자로 내용 변경하였습니다. (기존에 로그온 되어 있는 사용자 데이터를 조회함)