### PR TITLE
[REFACTOR] 소셜로그인 api 분기처리 및 컬럼 추가 

### DIFF
--- a/src/routers/AuthRouter.ts
+++ b/src/routers/AuthRouter.ts
@@ -1,10 +1,14 @@
 import { Router } from "express";
 import { AuthController } from "../controllers";
-import { body } from "express-validator";
+import { body, header } from "express-validator";
 
 const router: Router = Router();
 
-router.post("/", body("social").notEmpty(), AuthController.signIn);
+router.post(
+  "/",
+  [body("social").notEmpty(), header("authorization").notEmpty()],
+  AuthController.signIn,
+);
 router.get("/token", AuthController.getToken);
 
 export default router;

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -16,38 +16,81 @@ const signIn = async (authRequestDto: AuthRequestDto) => {
 
   const socialId = String(userInfo.id);
 
-  const user = await prisma.users.create({
-    data: {
-      social: authRequestDto.social,
-      social_id: socialId,
-      target_lang: "en",
-    },
-  });
-
-  if (!user) {
-    return null;
-  }
-  const userId = Number(user.id);
-
-  const refreshToken = jwtHandler.signRefreshToken();
-
-  await prisma.users.update({
-    data: {
-      refresh_token: refreshToken,
-    },
+  const userExist = await prisma.users.findFirst({
     where: {
-      id: user.id,
+      social_id: socialId,
     },
   });
 
-  const accessToken = jwtHandler.sign(userId);
+  if (!userExist) {
+    const user = await prisma.users.create({
+      data: {
+        social: authRequestDto.social,
+        social_id: socialId,
+        target_lang: "en",
+      },
+    });
 
-  const result = {
-    accessToken,
+    if (!user) {
+      return null;
+    }
+
+    const userId = Number(user.id);
+
+    const refreshToken = jwtHandler.signRefreshToken();
+
+    await prisma.users.update({
+      data: {
+        refresh_token: refreshToken,
+      },
+      where: {
+        id: userId,
+      },
+    });
+
+    const accessToken = jwtHandler.sign(userId);
+    const isRegistered = false;
+
+    return {
+      accessToken,
+      refreshToken,
+      isRegistered,
+    };
+  }
+
+  if (!userExist.refresh_token || !userExist.username) {
+    const isRegistered = false;
+
+    if (!userExist.refresh_token) {
+      const refreshToken = jwtHandler.signRefreshToken();
+      const accessToken = jwtHandler.sign(Number(userExist.id));
+
+      return {
+        refreshToken,
+        accessToken,
+        isRegistered,
+      };
+    }
+
+    const refreshToken = userExist.refresh_token;
+    const accessToken = jwtHandler.sign(Number(userExist.id));
+
+    return {
+      refreshToken,
+      accessToken,
+      isRegistered,
+    };
+  }
+
+  const isRegistered = true;
+  const refreshToken = userExist.refresh_token;
+  const accessToken = jwtHandler.sign(Number(userExist.id));
+
+  return {
     refreshToken,
+    accessToken,
+    isRegistered,
   };
-
-  return result;
 };
 
 const AuthService = {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #65 

## Work Description 💚
- 아래 요구사항에 맞춰, 소셜로그인 API를 수정했습니다.
> 소셜 로그인 api 후에 이전에 소셜토큰으로 접근했는지 여부를 확인하는 필드 (visited) 가 추가되었습니다~
case
Client 에서 카카오 로그인 후 oAuthAccessToken Server 로 전송 후
db 에 oAuthToken 존재 유무 판단
없으면 : 최초 로그인으로 판단 (isRegisterd : false) -> 닉네임 입력페이지로
있으면
해당 user 가 nickname 이 있는지 판단
없으면 : 최초 로그인으로 판단 (isRegisted : false) -> 닉네임 입력페이지로
있으면 : isRegisterd : true

- API test 화면 첨부합니다.
<img width="998" alt="스크린샷 2023-01-08 오후 2 50 55" src="https://user-images.githubusercontent.com/81692211/211182574-e4945372-f096-4b4a-a691-df409298f2ae.png">
