### PR TITLE
[ADD] 카테고리 및 랜덤 주제 빈 값 처리 로직 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,13 +16,13 @@ model categories {
 model diaries {
   id          Int         @id(map: "diaries_pk") @unique(map: "diaries_id_uindex") @default(autoincrement())
   user_id     Int
-  topic_id    Int
+  topic_id    Int?
   content     String
   target_lang String      @db.VarChar(10)
   is_public   Boolean
   created_at  DateTime    @db.Timestamp(6)
   updated_at  DateTime?   @db.Timestamp(6)
-  topics      topics      @relation(fields: [topic_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "diaries_topics_id_fk")
+  topics      topics?     @relation(fields: [topic_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "diaries_topics_id_fk")
   users       users       @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "diaries_users_id_fk")
   histories   histories[]
   likes       likes[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,13 +16,13 @@ model categories {
 model diaries {
   id          Int         @id(map: "diaries_pk") @unique(map: "diaries_id_uindex") @default(autoincrement())
   user_id     Int
-  topic_id    Int?
+  topic_id    Int
   content     String
   target_lang String      @db.VarChar(10)
   is_public   Boolean
   created_at  DateTime    @db.Timestamp(6)
   updated_at  DateTime?   @db.Timestamp(6)
-  topics      topics?     @relation(fields: [topic_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "diaries_topics_id_fk")
+  topics      topics      @relation(fields: [topic_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "diaries_topics_id_fk")
   users       users       @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "diaries_users_id_fk")
   histories   histories[]
   likes       likes[]

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -48,6 +48,20 @@ const getUserDiaryDetail = async (req: Request, res: Response) => {
   try {
     const data = await UserService.getDiaryByUserId(diaryGetRequestDto);
 
+    if (data === status.UNAUTHORIZED) {
+      res
+        .status(status.UNAUTHORIZED)
+        .send(fail(status.UNAUTHORIZED, message.INVALID_TOKEN));
+    }
+
+    if (data === status.INTERNAL_SERVER_ERROR) {
+      res
+        .status(status.INTERNAL_SERVER_ERROR)
+        .send(
+          fail(status.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR),
+        );
+    }
+
     if (!data) {
       res
         .status(status.BAD_REQUEST)

--- a/src/interfaces/diary/DiaryRequestDto.ts
+++ b/src/interfaces/diary/DiaryRequestDto.ts
@@ -2,7 +2,6 @@ export interface DiaryRequestDto {
   userId: string;
   content: string;
   targetLang: string;
-  category: string;
   topic: string;
   isPublic: boolean;
 }

--- a/src/routers/DiaryRouter.ts
+++ b/src/routers/DiaryRouter.ts
@@ -20,7 +20,6 @@ router.post(
   [
     body("content").notEmpty().isLength({ min: 10 }),
     body("targetLang").notEmpty(),
-    body("category").notEmpty(),
     body("topic").notEmpty(),
     body("isPublic").notEmpty(),
   ],

--- a/src/services/DiaryService.ts
+++ b/src/services/DiaryService.ts
@@ -25,14 +25,20 @@ const createDiary = async (diaryRequestDto: DiaryRequestDto) => {
     return status.UNAUTHORIZED;
   }
 
-  const topic = await prisma.topics.findUnique({
-    where: {
-      content: diaryRequestDto.topic,
-    },
-  });
+  let topicId = 1;
 
-  if (!topic) {
-    return null;
+  if (diaryRequestDto.topic) {
+    const topic = await prisma.topics.findUnique({
+      where: {
+        content: diaryRequestDto.topic,
+      },
+    });
+
+    if (!topic) {
+      return null;
+    }
+
+    topicId = topic.id;
   }
 
   const date = dayjs().format("YYYY-MM-DD HH:mm");
@@ -40,7 +46,7 @@ const createDiary = async (diaryRequestDto: DiaryRequestDto) => {
   const diary = await prisma.diaries.create({
     data: {
       user_id: +diaryRequestDto.userId,
-      topic_id: topic.id,
+      topic_id: topicId,
       content: diaryRequestDto.content,
       target_lang: diaryRequestDto.targetLang,
       is_public: diaryRequestDto.isPublic,

--- a/src/services/DiaryService.ts
+++ b/src/services/DiaryService.ts
@@ -11,6 +11,7 @@ import {
   OpenDiaryResponseDto,
 } from "../interfaces/diary/DiaryResponseDto";
 import { DiaryLikeDto } from "../interfaces/diary/DiaryLikeDto";
+import convertCategoryTopicToDto from "../utils/categoryTopic";
 
 const prisma = new PrismaClient();
 
@@ -102,23 +103,9 @@ const getDiaryById = async (diaryId: number, userId: number) => {
     return null;
   }
 
-  const topic = await prisma.topics.findUnique({
-    where: {
-      id: diary.topic_id,
-    },
-  });
+  const dto = await convertCategoryTopicToDto.convertTopicToDto(diary.topic_id);
 
-  if (!topic) {
-    return null;
-  }
-
-  const category = await prisma.categories.findUnique({
-    where: {
-      id: topic.category_id,
-    },
-  });
-
-  if (!category) {
+  if (!dto) {
     return status.INTERNAL_SERVER_ERROR;
   }
 
@@ -153,8 +140,8 @@ const getDiaryById = async (diaryId: number, userId: number) => {
   const data: DiaryResponseDto = {
     diaryId: diaryId,
     content: diary.content,
-    category: category.content,
-    topic: topic.content,
+    category: dto.category,
+    topic: dto.topic,
     likeCnt: likeCnt,
     createdAt: date,
     userId: writer.id,

--- a/src/utils/categoryTopic.ts
+++ b/src/utils/categoryTopic.ts
@@ -3,13 +3,13 @@ import { CategoryTopicDto } from "../interfaces/category/CategoryTopicDto";
 
 const prisma = new PrismaClient();
 
-const convertTopicToDto = async (topicId: number | null) => {
+const convertTopicToDto = async (topicId: number) => {
   const responseDto: CategoryTopicDto = {
     category: "",
     topic: "",
   };
 
-  if (!topicId) {
+  if (topicId === 1) {
     return responseDto;
   }
 

--- a/src/utils/categoryTopic.ts
+++ b/src/utils/categoryTopic.ts
@@ -9,7 +9,7 @@ const convertTopicToDto = async (topicId: number) => {
     topic: "",
   };
 
-  if (topicId === 1) {
+  if (topicId === 0) {
     return responseDto;
   }
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #81 

## Work Description 💚
- 카테고리 및 랜덤 주제 빈 값 처리 로직을 추가했습니다.
- 로직에 해당하는 일기 데이터 결과는 아래와 같음

```
{
    "status": 200,
    "success": true,
    "message": "일기 상세 조회 성공",
    "data": {
        "diaryId": 1,
        "content": "안녕하세요. 반가워요. 잘있어요.",
        "category": "",
        "topic": "",
        "likeCnt": 1,
        "createdAt": "2023-01-07 02:30",
        "userId": 19,
        "username": "스밈글작가",
        "bio": "안녕하세요 저는 스밈 글 작가입니다.",
        "hasLike": true
    }
}
```