### PR TITLE
[REFACTOR] 내 일기 목록 조회 date query 적용

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -112,10 +112,13 @@ const getUserInfo = async (req: Request, res: Response) => {
 
 const getUserDiaryList = async (req: Request, res: Response) => {
   const { userId } = req.body;
-  const { date } = req.query as unknown as string | undefined;
+  const { date } = req.query;
 
   try {
-    const data = await UserService.getUserDiaryList(+userId, date);
+    const data = await UserService.getUserDiaryList(
+      +userId,
+      date as string | undefined,
+    );
 
     if (!data) {
       return res

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -112,7 +112,7 @@ const getUserInfo = async (req: Request, res: Response) => {
 
 const getUserDiaryList = async (req: Request, res: Response) => {
   const { userId } = req.body;
-  const { date } = req.query;
+  const { date } = req.query as unknown as string | undefined;
 
   try {
     const data = await UserService.getUserDiaryList(+userId, date);

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -112,9 +112,10 @@ const getUserInfo = async (req: Request, res: Response) => {
 
 const getUserDiaryList = async (req: Request, res: Response) => {
   const { userId } = req.body;
+  const { date } = req.query;
 
   try {
-    const data = await UserService.getUserDiaryList(+userId);
+    const data = await UserService.getUserDiaryList(+userId, date);
 
     if (!data) {
       return res

--- a/src/interfaces/diary/DiaryResponseDto.ts
+++ b/src/interfaces/diary/DiaryResponseDto.ts
@@ -21,3 +21,11 @@ export interface OpenDiaryResponseDto {
   hasLike: boolean;
   createdAt: string;
 }
+
+export interface UserDiaryListGetResponseDto {
+  diaryId: number;
+  content: string;
+  createdAt: string;
+  isPublic: boolean;
+  likeCnt: number;
+}

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,3 +1,4 @@
+import { UserDiaryListGetResponseDto } from "./../interfaces/diary/DiaryResponseDto";
 import { DiaryGetRequestDto } from "./../interfaces/diary/DiaryRequestDto";
 import { PrismaClient } from "@prisma/client";
 import { UserRequestDto } from "../interfaces/user/UserRequestDto";
@@ -119,13 +120,7 @@ const getUserDiaryList = async (userId: number, date: string | undefined) => {
     );
   }
 
-  const userDiaryListGetResponseDto: {
-    diaryId: number;
-    content: string;
-    createdAt: string;
-    isPublic: boolean;
-    likeCnt: number;
-  }[] = [];
+  const userDiaryListGetResponseDto: UserDiaryListGetResponseDto[] = [];
 
   const promises = diaries.map(async (diary) => {
     const likeCnt = await prisma.likes.count({

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -96,7 +96,7 @@ const getUserInfo = async (userId: number) => {
   return result;
 };
 
-const getUserDiaryList = async (userId: number) => {
+const getUserDiaryList = async (userId: number, date: string | undefined) => {
   const user = await prisma.users.findUnique({
     where: {
       id: userId,
@@ -107,55 +107,47 @@ const getUserDiaryList = async (userId: number) => {
     return status.UNAUTHORIZED;
   }
 
-  const diaryList = await prisma.diaries.findMany({
+  let diaries = await prisma.diaries.findMany({
     where: {
       user_id: userId,
     },
   });
 
-  const userDiaryListGetResponseDto = [];
+  if (date !== undefined) {
+    diaries = diaries.filter(
+      (diary) => String(dayjs(diary.created_at).format("YYYY-MM-DD")) == date,
+    );
+  }
 
-  for (let i = 0; i < diaryList.length; i++) {
-    const topic = await prisma.topics.findFirst({
+  const userDiaryListGetResponseDto: {
+    diaryId: number;
+    content: string;
+    createdAt: string;
+    isPublic: boolean;
+    likeCnt: number;
+  }[] = [];
+
+  const promises = diaries.map(async (diary) => {
+    const likeCnt = await prisma.likes.count({
       where: {
-        id: diaryList[i].topic_id,
-      },
-      select: {
-        category_id: true,
+        diary_id: diary.id,
       },
     });
-
-    if (!topic) {
-      return status.INTERNAL_SERVER_ERROR;
-    }
-
-    const diary = await prisma.diaries.findUnique({
-      where: {
-        id: diaryList[i].id,
-      },
-      include: {
-        _count: {
-          select: { likes: true },
-        },
-      },
-    });
-
-    if (!diary) {
-      return status.INTERNAL_SERVER_ERROR;
-    }
-
-    const likeCnt = diary._count.likes;
-
-    const UserDiaryGetResponseDto = {
-      diaryId: diaryList[i].id,
-      content: diaryList[i].content,
-      createdAt: dayjs(diaryList[i].created_at).format("YYYY-MM-DD HH:mm"),
-      isPublic: diaryList[i].is_public,
+    const data = {
+      diaryId: diary.id,
+      content: diary.content,
+      createdAt: dayjs(diary.created_at).format("YYYY-MM-DD HH:mm"),
+      isPublic: diary.is_public,
       likeCnt: likeCnt,
     };
 
-    userDiaryListGetResponseDto.push(UserDiaryGetResponseDto);
-  }
+    userDiaryListGetResponseDto.push(data);
+  });
+  await Promise.all(promises);
+
+  userDiaryListGetResponseDto.sort(function (a, b) {
+    return a.createdAt > b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
+  });
 
   return userDiaryListGetResponseDto;
 };


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #107 

## Work Description 💚
- 내 일기 목록조회에서 query string을 추가하여, 해당 날짜에 해당하는 일기를 조회 할 수 있도록 리팩토링 진행했습니다.

- date query 적용
<img width="967" alt="image" src="https://user-images.githubusercontent.com/81692211/211299136-945467a3-e343-4229-99e0-14af04e31c70.png">
- date query 없을 때는 전부 반환
<img width="959" alt="image" src="https://user-images.githubusercontent.com/81692211/211299228-85589eb8-2133-43ff-a45a-fa30ebece922.png">

