### PR TITLE
[REFACTOR] list 조회 API response data 수정

### DIFF
--- a/src/services/DiaryService.ts
+++ b/src/services/DiaryService.ts
@@ -240,7 +240,9 @@ const getOpenDiaries = async (
     return a.createdAt > b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
   });
 
-  return result;
+  return {
+    diaries: result,
+  };
 };
 
 const updateDiary = async (diaryUpdateRequestDto: DiaryUpdateRequestDto) => {

--- a/src/services/ScrapService.ts
+++ b/src/services/ScrapService.ts
@@ -72,7 +72,7 @@ const getScrapsByUser = async (userId: number) => {
     return a.createdAt > b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
   });
 
-  return result;
+  return { scraps: result };
 };
 
 const deleteScrapById = async (userId: number, scrapId: number) => {

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -146,7 +146,7 @@ const getUserDiaryList = async (userId: number, date: string | undefined) => {
     return a.createdAt > b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
   });
 
-  return userDiaryListGetResponseDto;
+  return { diaries: userDiaryListGetResponseDto };
 };
 
 const UserService = {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #121 

## Work Description 💚
- 클라이언트의 요청에 따라, response data 형식을 변경했습니다.
```
data : [
  {...}, {...}, ...
] 
```
에서
``` 
data: {
  diaries: [
{...}, {...}, ...
]
}
```
로 변경했습니다.


- 오픈 게시판 조회 API response data 변경
  - Test 스크린 샷 첨부합니다.

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/81692211/211695331-f0435f72-a137-44a9-a009-3dd7e69b1449.png">

  
- 유저 일기 목록 조회 API response data 변경
  - Test 스크린 샷 첨부합니다.
  
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/81692211/211695263-815dab58-5ebb-425c-b25e-ac25544ab83d.png">

- 스크랩 목록 조회 API response data 변경
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/81692211/211695649-efb1990a-f797-4dcc-b509-1dbee90c9bac.png">
